### PR TITLE
AWS Batch with CWL: did not localize cwl.inputs.json 

### DIFF
--- a/centaur/src/main/resources/standardTestCases/ad_hoc_file_test.aws.test
+++ b/centaur/src/main/resources/standardTestCases/ad_hoc_file_test.aws.test
@@ -1,0 +1,14 @@
+name: ad_hoc_file_test.aws
+testFormat: workflowsuccess
+backends: [ AWSBATCH ]
+
+files {
+  workflow: ad_hoc_file_test/workflow.cwl
+  imports: [
+    ad_hoc_file_test/cwl-test.cwl
+  ]
+}
+
+metadata {
+  status: Succeeded
+}

--- a/centaur/src/main/resources/standardTestCases/ad_hoc_file_test/cwl-test.cwl
+++ b/centaur/src/main/resources/standardTestCases/ad_hoc_file_test/cwl-test.cwl
@@ -1,0 +1,21 @@
+class: CommandLineTool
+cwlVersion: v1.0
+baseCommand: ["sh", "example.sh"]
+hints:
+  DockerRequirement:
+    dockerPull: ubuntu:latest
+inputs: []
+
+requirements:
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: example.sh
+        entry: |-
+          PREFIX='Message is:'
+          MSG="\${PREFIX} Hello world!"
+          echo \${MSG}
+
+outputs:
+  example_out:
+    type: stdout
+stdout: output.txt

--- a/centaur/src/main/resources/standardTestCases/ad_hoc_file_test/workflow.cwl
+++ b/centaur/src/main/resources/standardTestCases/ad_hoc_file_test/workflow.cwl
@@ -1,0 +1,10 @@
+cwlVersion: v1.0
+class: Workflow
+inputs: []
+outputs: []
+
+steps:
+  test:
+    run: cwl-test.cwl
+    in: []
+    out: []

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -56,7 +56,6 @@ import cromwell.services.keyvalue.KeyValueServiceActor._
 import cromwell.services.keyvalue.KvClient
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.services.batch.model.{BatchException, SubmitJobResponse}
-import wom.CommandSetupSideEffectFile
 import wom.callable.Callable.OutputDefinition
 import wom.core.FullyQualifiedName
 import wom.expression.NoIoFunctionSet
@@ -185,26 +184,9 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     }
   }
 
-  /**
-    * Turns WomFiles into relative paths.  These paths are relative to the working disk.
-    *
-    * relativeLocalizationPath("foo/bar.txt") -> "foo/bar.txt"
-    * relativeLocalizationPath("s3://some/bucket/foo.txt") -> "some/bucket/foo.txt"
-    */
-  private def relativeLocalizationPath(file: WomFile): WomFile = {
-    file.mapFile(value =>
-      getPath(value) match {
-        case Success(path) => path.pathWithoutScheme
-        case _ => value
-      }
-    )
-  }
-
   private[aws] def generateAwsBatchInputs(jobDescriptor: BackendJobDescriptor): Set[AwsBatchInput] = {
     val writeFunctionFiles = instantiatedCommand.createdFiles map { f => f.file.value.md5SumShort -> List(f) } toMap
 
-    def localizationPath(f: CommandSetupSideEffectFile) =
-      f.relativeLocalPath.fold(ifEmpty = relativeLocalizationPath(f.file))(WomFile(f.file.womFileType, _))
     val writeFunctionInputs = writeFunctionFiles flatMap {
       case (name, files) => inputsFromWomFiles(name, files.map(_.file), files.map(localizationPath), jobDescriptor)
     }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -37,7 +37,6 @@ import cromwell.services.keyvalue.KvClient
 import cromwell.services.metadata.CallMetadataKeys
 import shapeless.Coproduct
 import wdl4s.parser.MemoryUnit
-import wom.CommandSetupSideEffectFile
 import wom.callable.AdHocValue
 import wom.callable.Callable.OutputDefinition
 import wom.callable.MetaValueElement.{MetaValueElementBoolean, MetaValueElementObject}
@@ -167,7 +166,7 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
     * relativeLocalizationPath("foo/bar.txt") -> "foo/bar.txt"
     * relativeLocalizationPath("gs://some/bucket/foo.txt") -> "some/bucket/foo.txt"
     */
-  protected def relativeLocalizationPath(file: WomFile): WomFile = {
+  override protected def relativeLocalizationPath(file: WomFile): WomFile = {
     file.mapFile(value =>
       getPath(value) match {
         case Success(drsPath: DrsPath) => DrsResolver.getContainerRelativePath(drsPath).unsafeRunSync()
@@ -177,7 +176,7 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
     )
   }
 
-  protected def fileName(file: WomFile): WomFile = {
+  override protected def fileName(file: WomFile): WomFile = {
     file.mapFile(value =>
       getPath(value) match {
         case Success(drsPath: DrsPath) => DefaultPathBuilder.get(DrsResolver.getContainerRelativePath(drsPath).unsafeRunSync()).name
@@ -210,11 +209,6 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
           case womFile: WomFile => womFile
         }
     }
-  }
-
-  protected def localizationPath(f: CommandSetupSideEffectFile) = {
-    val fileTransformer = if (isAdHocFile(f.file)) fileName _ else relativeLocalizationPath _
-    f.relativeLocalPath.fold(ifEmpty = fileTransformer(f.file))(WomFile(f.file.womFileType, _))
   }
 
   private[pipelines] def generateInputs(jobDescriptor: BackendJobDescriptor): Set[PipelinesApiInput] = {


### PR DESCRIPTION
I think that the problem is related to the methods `generateInputs` (PipelinesApiAsyncBackendJobExecutionActor) and `generateAwsBatchInputs` (AwsBatchAsyncBackendJobExecutionActor).
Both of them use the `localizationPath` method. Except in the PipelinesApi it is a regular method, while in AwsBatch it is a nested method. These methods are similar, but in PipelinesApi this method checks whether the file is ad hoc, and in that case handles it differently. Adding the same check to the AwsBatch method solves the problem.
Ultimately, it should be enough to just copypaste this check to AwsBatch and everything would work. However, I believe that copypasting caused this problem in the first place. Therefore, the code of the PipelinesApi and AwsBatch refactored a little bit to reduce redundancy.
Also for now I'm not sure about `mapCommandLineWomFile`, `mapCommandLineJobInputWomFile` and `localizeAdHocValues` methods. On the one hand, PipelinesApi has some special cases for the ad hoc files. On the other hand, in my tests, AwsBatch works fine even without that special wiring 🙂