### PR TITLE
Copying of outputs and logs implemented

### DIFF
--- a/centaur/src/main/resources/integrationTestCases/copy_files_aws.test
+++ b/centaur/src/main/resources/integrationTestCases/copy_files_aws.test
@@ -1,0 +1,20 @@
+name: cwl_input_json
+testFormat: workflowsuccess
+workflowType: WDL
+workflowRoot: my_test_case-1
+backends: [Papiv2]
+tags: [copy_false]
+
+
+files {
+    workflow: copy_files_wdl.wdl
+    options: aws_cromwell_options.json
+    workflow: and_another_one.wdl
+}
+
+metadata {
+  workflowName: copy_files_wdl
+  status: Succeeded
+  workflowName: and_another_one
+  status: Succeeded
+}

--- a/centaur/src/main/resources/integrationTestCases/copy_files_aws_relative_path.test
+++ b/centaur/src/main/resources/integrationTestCases/copy_files_aws_relative_path.test
@@ -1,0 +1,16 @@
+name: copy_files_aws_relative
+testFormat: workflowsuccess
+backends: [AWSBatch]
+workflowType: WDL
+tags: [copyTrue]
+
+
+files {
+    workflow: copy_tests/echo_string.wdl
+    workflow: copy_tests/copy_files_aws_relative_path/steps/check_copied_aws_relative.wdl
+    options: copy_tests/copy_files_aws_relative_path/aws_cromwell_options.json
+}
+
+metadata {
+    status: Succeeded
+}

--- a/centaur/src/main/resources/integrationTestCases/copy_tests/copy_files_aws/aws_cromwell_options.json
+++ b/centaur/src/main/resources/integrationTestCases/copy_tests/copy_files_aws/aws_cromwell_options.json
@@ -1,0 +1,6 @@
+{
+  "final_workflow_outputs_dir":"s3://cromwell-bucket-ssvitkov/wf_results",
+  "use_relative_output_paths":false,
+  "final_workflow_log_dir":"s3://cromwell-bucket-ssvitkov/wf_logs",
+  "final_call_logs_dir":"s3://cromwell-bucket-ssvitkov/cl_logs"
+}

--- a/centaur/src/main/resources/integrationTestCases/copy_tests/copy_files_aws/steps/check_copied_aws.wdl
+++ b/centaur/src/main/resources/integrationTestCases/copy_tests/copy_files_aws/steps/check_copied_aws.wdl
@@ -1,0 +1,54 @@
+import "../../echo_string.wdl" as sub
+
+workflow check_copied_aws {
+
+   call sub.echo_string
+
+   output {
+      File output_file = echo_string.output_file
+   }
+
+    String filename = "s3://cromwell-bucket-ssvitkov/wf_result/output.txt"
+    String filename1 = "s3://cromwell-bucket-ssvitkov/wf_logs/MergeGVCFs-stderr.log"
+    String filename2 = "s3://cromwell-bucket-ssvitkov/wf_logs/MergeGVCFs-stdout.log"
+
+    String directory_name = "s3://my-bucket-name-34/wf_logs"
+
+    call CheckFiles {
+        input: filename = filename,
+            filename1 = filename1,
+            filename2 = filename2,
+            directory_name = directory_name
+    }
+}
+
+task CheckFiles {
+
+    String filename
+    String filename1
+    String filename2
+    String directory_name
+
+    Int machine_mem_gb = 2
+    Int command_mem_gb = machine_mem_gb - 1
+
+    command {
+        //does output.txt exist
+        ( if [ -f ${filename} ]; then echo "$filename exists"; fi)
+
+        //does workflow logs exist
+        cd ~/${directory_name}
+        ( if [ -z "$(ls)" ]; then echo "workflow logs are existing \n ls output: $(ls)"; else echo "something wrong"; fi; )
+
+        //does MergeGVCFs-stderr.log and MergeGVCFs-stdout.log exist
+        ( if [ -f ${filename1} ]; then echo "$filename1 exists"; else echo "something wrong"; fi; )
+        ( if [ -f ${filename2} ]; then echo "$filename2 exists"; else echo "something wrong"; fi; )
+    }
+
+
+    runtime {
+        docker: "ubuntu"
+        memory: "${machine_mem_gb}G"
+        cpu: 1
+    }
+}

--- a/centaur/src/main/resources/integrationTestCases/copy_tests/copy_files_aws_relative_path/aws_cromwell_options.json
+++ b/centaur/src/main/resources/integrationTestCases/copy_tests/copy_files_aws_relative_path/aws_cromwell_options.json
@@ -1,0 +1,6 @@
+{
+  "final_workflow_outputs_dir":"s3://cromwell-bucket-ssvitkov/wf_results",
+  "use_relative_output_paths":true,
+  "final_workflow_log_dir":"s3://cromwell-bucket-ssvitkov/wf_logs",
+  "final_call_logs_dir":"s3://cromwell-bucket-ssvitkov/cl_logs"
+}

--- a/centaur/src/main/resources/integrationTestCases/copy_tests/copy_files_aws_relative_path/steps/check_copied_aws_relative.wdl
+++ b/centaur/src/main/resources/integrationTestCases/copy_tests/copy_files_aws_relative_path/steps/check_copied_aws_relative.wdl
@@ -1,0 +1,37 @@
+workflow check_copied_aws_relative {
+    String filename = "wf_results/output.txt"
+    String directory_name = "wf_logs"
+
+    call CheckFiles {
+        input:
+            filename = filename,
+            directory_name = directory_name
+    }
+}
+
+task CheckFiles {
+    String filename
+    String directory_name
+
+    Int machine_mem_gb = 2
+    Int command_mem_gb = machine_mem_gb - 1
+
+    command {
+       #does output.txt exist
+       ( if [ -f ~/${filename} ]; then echo "$filename exists"; else exit 1; fi)
+
+       #does workflow logs exist
+       cd ~/${directory_name}
+      ( if [ -z "$(ls)" ]; then echo "workflow logs exists,\n ls output: \n $(ls)"; else exit 1; fi; )
+
+       #does stderr.log and stdout.log exist
+       ( if [ -f ~/$(find cl_logs/ -name 'echo-stderr*') ]; then echo "file stderr exists"; else exit 1; fi)
+       ( if [ -f ~/$(find cl_logs/ -name 'echo-stdout*') ]; then echo "file stdout exists"; else exit 1; fi)
+    }
+
+    runtime {
+        docker: "ubuntu"
+        memory: "${machine_mem_gb}G"
+        cpu: 1
+    }
+}

--- a/centaur/src/main/resources/integrationTestCases/copy_tests/echo_string.wdl
+++ b/centaur/src/main/resources/integrationTestCases/copy_tests/echo_string.wdl
@@ -1,0 +1,35 @@
+workflow echo_string {
+    String input_str = "Hello there!"
+
+    # Merge per-interval GVCFs
+    call echo {
+            input: input_str = input_str
+     }
+
+    # Outputs that will be retained when execution is complete
+    output {
+            File output_file = echo.output_file
+    }
+}
+
+task echo {
+    String input_str
+    String output_file_name = "output.txt"
+
+    Int machine_mem_gb = 2
+    Int command_mem_gb = machine_mem_gb - 1
+
+    command {
+      echo ${input_str} > ${output_file_name}
+    }
+
+    runtime {
+        docker: "ubuntu"
+        memory: "${machine_mem_gb}G"
+        cpu: 1
+    }
+
+    output {
+            File output_file = "${output_file_name}"
+    }
+}

--- a/core/src/main/scala/cromwell/core/path/PathCopier.scala
+++ b/core/src/main/scala/cromwell/core/path/PathCopier.scala
@@ -40,10 +40,9 @@ object PathCopier {
     * Copies from source to destination. NOTE: Copies are not atomic, and may create a partial copy.
     */
   def copy(sourceFilePath: Path, destinationFilePath: Path): Try[Unit] = {
-    Option(destinationFilePath.parent).foreach(_.createPermissionedDirectories())
     Try {
+      Option(destinationFilePath.parent).foreach(_.createDirectories)
       sourceFilePath.copyTo(destinationFilePath, overwrite = true)
-
       ()
     } recoverWith {
       case ex => Failure(new IOException(s"Failed to copy $sourceFilePath to $destinationFilePath", ex))

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowLogsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowLogsActor.scala
@@ -33,7 +33,6 @@ class CopyWorkflowLogsActor(override val serviceRegistryActor: ActorRef, overrid
   implicit val ec = context.dispatcher
   
   def copyLog(src: Path, dest: Path, workflowId: WorkflowId) = {
-    dest.parent.createPermissionedDirectories()
     // Send the workflowId as context along with the copy so we can update metadata when the response comes back
     sendIoCommandWithContext(GcsBatchCommandBuilder.copyCommand(src, dest, overwrite = true), workflowId)
     // In order to keep "copy and then delete" operations atomic as far as monitoring is concerned, removeWork will only be called

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
@@ -68,9 +68,7 @@ class CopyWorkflowOutputsActor(workflowId: WorkflowId, override val ioActor: Act
           s" as multiple files will be copied to the same path: \n${formattedCollidingCopyOptions.mkString("\n")}")}
 
     val copies = outputFilePaths map {
-      case (srcPath, dstPath) => 
-        dstPath.createDirectories()
-        asyncIo.copyAsync(srcPath, dstPath)
+      case (srcPath, dstPath) => asyncIo.copyAsync(srcPath, dstPath)
     }
     
     Future.sequence(copies)
@@ -99,7 +97,8 @@ class CopyWorkflowOutputsActor(workflowId: WorkflowId, override val ioActor: Act
     // the call-.* part is there to prevent arbitrary folders called execution to get caught.
     // Truncate regex is declared here. If it were declared in the if statement the regex would have to be
     // compiled for every single file.
-    lazy val truncateRegex = ".*/call-.*/execution/".r
+    // "execution" should be optional, because its not created on AWS.
+    lazy val truncateRegex = ".*\\/call-.*\\/(execution\\/)?".r
     val outputFileDestinations = rootAndFiles flatMap {
       case (workflowRoot, outputs) =>
         outputs map { output => 

--- a/filesystems/s3/src/main/java/org/lerch/s3fs/util/AmazonS3ClientProvider.java
+++ b/filesystems/s3/src/main/java/org/lerch/s3fs/util/AmazonS3ClientProvider.java
@@ -1,0 +1,41 @@
+package org.lerch.s3fs.util;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.Objects;
+
+public class AmazonS3ClientProvider {
+    private final AwsCredentials credentials;
+    private final Region region;
+    private static AmazonS3ClientProvider instance;
+
+    public static void init(AwsCredentials credentials, Region region) {
+        if (Objects.isNull(instance))
+            instance = new AmazonS3ClientProvider(credentials, region);
+    }
+
+    public static AmazonS3 buildAmazonS3Client() throws AssertionError {
+        if (Objects.isNull(instance))
+            throw new AssertionError("AmazonS3ClientProvider instance should no be null!");
+
+        final AwsCredentials creds = instance.credentials;
+        final Region reg = instance.region;
+
+        final BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(creds.accessKeyId(),
+                creds.secretAccessKey());
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .withRegion(reg.id())
+                .build();
+    }
+
+    private AmazonS3ClientProvider(AwsCredentials credentials, Region region) {
+        this.credentials = credentials;
+        this.region = region;
+    }
+}

--- a/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilder.scala
+++ b/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilder.scala
@@ -41,7 +41,7 @@ import cromwell.core.WorkflowOptions
 import cromwell.core.path.{NioPath, Path, PathBuilder}
 import cromwell.filesystems.s3.S3PathBuilder._
 import org.lerch.s3fs.S3FileSystemProvider
-import org.lerch.s3fs.util.S3Utils
+import org.lerch.s3fs.util.{AmazonS3ClientProvider, S3Utils}
 import software.amazon.awssdk.regions.Region
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -130,12 +130,13 @@ object S3PathBuilder {
                       configuration: S3Configuration,
                       options: WorkflowOptions,
                       storageRegion: Option[Region]): S3PathBuilder = {
+    AmazonS3ClientProvider.init(credentials, storageRegion.getOrElse(Region.US_EAST_2))
     new S3PathBuilder(S3Storage.s3Client(credentials, storageRegion), configuration)
   }
 }
 
 class S3PathBuilder(client: S3Client,
-                     configuration: S3Configuration
+                    configuration: S3Configuration
                      ) extends PathBuilder {
   // Tries to create a new S3Path from a String representing an absolute s3 path: s3://<bucket>[/<key>].
   def build(string: String): Try[S3Path] = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,6 +12,7 @@ object Dependencies {
   private val apacheCommonNetV = "3.6"
   private val apacheHttpClientV = "4.5.7"
   private val awsSdkV = "2.3.9"
+  private val amazonAwsV = "1.11.500"
   private val betterFilesV = "2.17.1"
   private val catsEffectV = "1.2.0"
   private val catsV = "1.5.0"
@@ -262,6 +263,7 @@ object Dependencies {
 
   private val awsCloudDependencies = List(
     "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonV,
+    "com.amazonaws" % "aws-java-sdk-s3" % amazonAwsV
   ) ++ s3fsDependencies ++ List(
     "batch",
     "core",


### PR DESCRIPTION
Fix of this issue: https://github.com/broadinstitute/cromwell/issues/4982
Changes:
- Implemented file transferring via `TransferManager`
- Removed assertions that caused `copying directories is not yet supported` exception
- Fixed incorrect work of `use_relative_output_paths` option
- Fixed logs and output files copying (tested on following backends: local, AWS, GCP).