### PR TITLE
Fix call cache checks in case of cache invalidation [CROM-6603]

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
@@ -82,12 +82,12 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
     runTransaction(action)
   }
 
-  override def findCacheHitForAggregation(baseAggregationHash: String, inputFilesAggregationHash: Option[String], callCachePathPrefixes: Option[List[String]], hitNumber: Int)
+  override def findCacheHitForAggregation(baseAggregationHash: String, inputFilesAggregationHash: Option[String], callCachePathPrefixes: Option[List[String]], excludedIds: Set[Int])
                                          (implicit ec: ExecutionContext): Future[Option[Int]] = {
 
     val action = callCachePathPrefixes match {
       case None =>
-        dataAccess.callCachingEntriesForAggregatedHashes(baseAggregationHash, inputFilesAggregationHash, hitNumber).result.headOption
+        dataAccess.callCachingEntriesForAggregatedHashes(baseAggregationHash, inputFilesAggregationHash, excludedIds).result.headOption
       case Some(ps) =>
         val one :: two :: three :: _ = prefixesAndLengths(ps)
         dataAccess.callCachingEntriesForAggregatedHashesWithPrefixes(
@@ -95,7 +95,7 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
           one.prefix, one.length,
           two.prefix, two.length,
           three.prefix, three.length,
-          hitNumber).result.headOption
+          excludedIds).result.headOption
     }
 
     runTransaction(action)

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingAggregationEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingAggregationEntryComponent.scala
@@ -69,26 +69,26 @@ trait CallCachingAggregationEntryComponent {
         (detritusPath.substring(0, prefix3Length) === prefix3)} yield ()).exists
   )
 
-  def callCachingEntriesForAggregatedHashes(baseAggregation: Rep[String], inputFilesAggregation: Rep[Option[String]], number: Int) = {
+  def callCachingEntriesForAggregatedHashes(baseAggregation: Rep[String], inputFilesAggregation: Rep[Option[String]], excludedIds: Set[Int]) = {
     (for {
       callCachingEntry <- callCachingEntries
-      if callCachingEntry.allowResultReuse
+      if callCachingEntry.allowResultReuse && !(callCachingEntry.callCachingEntryId inSet excludedIds)
       callCachingAggregationEntry <- callCachingAggregationEntries
       if callCachingEntry.callCachingEntryId === callCachingAggregationEntry.callCachingEntryId
       if callCachingAggregationEntry.baseAggregation === baseAggregation
       if (callCachingAggregationEntry.inputFilesAggregation.isEmpty && inputFilesAggregation.isEmpty) ||
         (callCachingAggregationEntry.inputFilesAggregation === inputFilesAggregation)
-    } yield callCachingAggregationEntry.callCachingEntryId).drop(number - 1).take(1)
+    } yield callCachingAggregationEntry.callCachingEntryId).take(1)
   }
 
   def callCachingEntriesForAggregatedHashesWithPrefixes(baseAggregation: Rep[String], inputFilesAggregation: Rep[Option[String]],
                                                         prefix1: Rep[String], prefix1Length: Rep[Int],
                                                         prefix2: Rep[String], prefix2Length: Rep[Int],
                                                         prefix3: Rep[String], prefix3Length: Rep[Int],
-                                                        number: Int) = {
+                                                        excludedIds: Set[Int]) = {
     (for {
       callCachingEntry <- callCachingEntries
-      if callCachingEntry.allowResultReuse
+      if callCachingEntry.allowResultReuse && !(callCachingEntry.callCachingEntryId inSet excludedIds)
       callCachingAggregationEntry <- callCachingAggregationEntries
       if callCachingEntry.callCachingEntryId === callCachingAggregationEntry.callCachingEntryId
       if callCachingAggregationEntry.baseAggregation === baseAggregation
@@ -103,6 +103,6 @@ trait CallCachingAggregationEntryComponent {
       if (detritusPath.substring(0, prefix1Length) === prefix1) ||
         (detritusPath.substring(0, prefix2Length) === prefix2) ||
         (detritusPath.substring(0, prefix3Length) === prefix3)
-    } yield callCachingAggregationEntry.callCachingEntryId).drop(number - 1).take(1)
+    } yield callCachingAggregationEntry.callCachingEntryId).take(1)
   }
 }

--- a/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
@@ -11,7 +11,7 @@ trait CallCachingSqlDatabase {
   def hasMatchingCallCachingEntriesForBaseAggregation(baseAggregationHash: String, callCachePathPrefixes: Option[List[String]])
                                                      (implicit ec: ExecutionContext): Future[Boolean]
 
-  def findCacheHitForAggregation(baseAggregationHash: String, inputFilesAggregationHash: Option[String], callCachePathPrefixes: Option[List[String]], hitNumber: Int)
+  def findCacheHitForAggregation(baseAggregationHash: String, inputFilesAggregationHash: Option[String], callCachePathPrefixes: Option[List[String]], excludedIds: Set[Int])
                                 (implicit ec: ExecutionContext): Future[Option[Int]]
 
   def queryResultsForCacheId(callCachingEntryId: Int)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
@@ -77,13 +77,13 @@ class CallCache(database: CallCachingSqlDatabase) {
     database.hasMatchingCallCachingEntriesForBaseAggregation(baseAggregatedHash, ccpp)
   }
 
-  def callCachingHitForAggregatedHashes(aggregatedCallHashes: AggregatedCallHashes, prefixesHint: Option[CallCachePathPrefixes], hitNumber: Int)
+  def callCachingHitForAggregatedHashes(aggregatedCallHashes: AggregatedCallHashes, prefixesHint: Option[CallCachePathPrefixes], excludedIds: Set[CallCachingEntryId])
                                        (implicit ec: ExecutionContext): Future[Option[CallCachingEntryId]] = {
     database.findCacheHitForAggregation(
       baseAggregationHash = aggregatedCallHashes.baseAggregatedHash,
       inputFilesAggregationHash = aggregatedCallHashes.inputFilesAggregatedHash,
       callCachePathPrefixes = prefixesHint.map(_.prefixes),
-      hitNumber).map(_ map CallCachingEntryId.apply)
+      excludedIds.map(_.id)).map(_ map CallCachingEntryId.apply)
   }
 
   def fetchCachedResult(callCachingEntryId: CallCachingEntryId)(implicit ec: ExecutionContext): Future[Option[CallCachingJoin]] = {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
@@ -33,8 +33,8 @@ class CallCacheReadActor(cache: CallCache,
           case true => HasMatchingEntries
           case false => NoMatchingEntries
         }
-      case CacheLookupRequest(aggregatedCallHashes, cacheHitNumber, prefixesHint) =>
-        cache.callCachingHitForAggregatedHashes(aggregatedCallHashes, prefixesHint, cacheHitNumber) map {
+      case CacheLookupRequest(aggregatedCallHashes, excludedIds, prefixesHint) =>
+        cache.callCachingHitForAggregatedHashes(aggregatedCallHashes, prefixesHint, excludedIds) map {
           case Some(nextHit) => CacheLookupNextHit(nextHit)
           case None => CacheLookupNoHit
         }
@@ -78,7 +78,7 @@ object CallCacheReadActor {
   case class AggregatedCallHashes(baseAggregatedHash: String, inputFilesAggregatedHash: Option[String])
 
   sealed trait CallCacheReadActorRequest
-  final case class CacheLookupRequest(aggregatedCallHashes: AggregatedCallHashes, cacheHitNumber: Int, prefixesHint: Option[CallCachePathPrefixes]) extends CallCacheReadActorRequest
+  final case class CacheLookupRequest(aggregatedCallHashes: AggregatedCallHashes, excludedIds: Set[CallCachingEntryId], prefixesHint: Option[CallCachePathPrefixes]) extends CallCacheReadActorRequest
   final case class HasMatchingInitialHashLookup(aggregatedTaskHash: String, cacheHitHints: List[CacheHitHint] = List.empty) extends CallCacheReadActorRequest
   final case class CallCacheEntryForCall(workflowId: WorkflowId, jobKey: BackendJobDescriptorKey) extends CallCacheReadActorRequest
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCachingSlickDatabaseSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCachingSlickDatabaseSpec.scala
@@ -103,7 +103,7 @@ class CallCachingSlickDatabaseSpec
             "BASE_AGGREGATION",
             Option("FILE_AGGREGATION"),
             callCachePathPrefixes = prefixOption,
-            1
+            Set.empty
           )
           _ = hit shouldBe empty
         } yield ()).futureValue


### PR DESCRIPTION
Closes https://broadworkbench.atlassian.net/browse/CROM-6603.
Instead of storing a `hitNumber` (which in fact an offset), now it explicitly stores cache ids that were already seen.